### PR TITLE
Start server with access to 'production' data

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,14 @@ Install dependencies:
 yarn install
 ```
 
-Start server:
+Start local server:
 ```
 DEBUG=blockstack-web:* npm start
+```
+
+Start local server with access to "production" data:
+```
+APP_DOMAIN=https://envelop.app DEBUG=blockstack-web:* npm start
 ```
 
 Open in  browser:

--- a/bin/www
+++ b/bin/www
@@ -16,7 +16,9 @@ var port = normalizePort(process.env.PORT || '3000');
 app.set('port', port);
 
 // Config
-if (process.env.NODE_ENV === 'production') {
+if (process.env.APP_DOMAIN) {
+  app.set('appDomain', process.env.APP_DOMAIN);
+} else if (process.env.NODE_ENV === 'production') {
   app.set('appDomain', 'https://envelop.app');
 } else {
   app.set('appDomain', 'http://localhost:' + app.get('port'));


### PR DESCRIPTION
This PR enables us to get access to "production" files by adding the following env variable on server startup:

```
APP_DOMAIN=https://envelop.server npm start
```